### PR TITLE
[update] #27 魔獣缶・シールの効果が重複しないように修正

### DIFF
--- a/docs/js/calc.js
+++ b/docs/js/calc.js
@@ -1,5 +1,133 @@
 // 計算の処理系群
 
+class PISVL{
+    // POW、INT、SPD、VIT、LUK を管理するクラス
+    constructor(pow=0, int=0, spd=0, vit=0, luk=0) {
+        this.pow = pow;
+        this.int = int;
+        this.spd = spd;
+        this.vit = vit;
+        this.luk = luk;
+    }
+    get pow() {
+        return this._pow;
+    }
+    set pow(value) {
+        this._pow = value;
+    }
+    get int() {
+        return this._int;
+    }
+    set int(value) {
+        this._int = value;
+    }
+    get spd() {
+        return this._spd;
+    }
+    set spd(value) {
+        this._spd = value;
+    }
+    get vit() {
+        return this._vit;
+    }
+    set vit(value) {
+        this._vit = value;
+    }
+    get luk() {
+        return this._luk;
+    }
+    set luk(value) {
+        this._luk = value;
+    }
+    reset() {
+        this._pow = 0;
+        this._int = 0;
+        this._spd = 0;
+        this._vit = 0;
+        this._luk = 0;
+    }
+}
+
+class PISVLADMaMd{
+    // POW、INT、SPD、VIT、LUK、ATK、DEF、MAT、MDF を管理するクラス
+    constructor(pow=0, int=0, spd=0, vit=0, luk=0, atk=0, def=0, mat=0, mdf=0) {
+        this.pow = pow;
+        this.int = int;
+        this.spd = spd;
+        this.vit = vit;
+        this.luk = luk;
+        this.atk = atk;
+        this.def = def;
+        this.mat = mat;
+        this.mdf = mdf;
+    }
+    get pow() {
+        return this._pow;
+    }
+    set pow(value) {
+        this._pow = value;
+    }
+    get int() {
+        return this._int;
+    }
+    set int(value) {
+        this._int = value;
+    }
+    get spd() {
+        return this._spd;
+    }
+    set spd(value) {
+        this._spd = value;
+    }
+    get vit() {
+        return this._vit;
+    }
+    set vit(value) {
+        this._vit = value;
+    }
+    get luk() {
+        return this._luk;
+    }
+    set luk(value) {
+        this._luk = value;
+    }
+    get atk() {
+        return this._atk;
+    }
+    set atk(value) {
+        this._atk = value;
+    }
+    get def() {
+        return this._def;
+    }
+    set def(value) {
+        this._def = value;
+    }
+    get mat() {
+        return this._mat;
+    }
+    set mat(value) {
+        this._mat = value;
+    }
+    get mdf() {
+        return this._mdf;
+    }
+    set mdf(value) {
+        this._mdf = value;
+    }
+    reset() {
+        this._pow = 0;
+        this._int = 0;
+        this._spd = 0;
+        this._vit = 0;
+        this._luk = 0;
+        this._atk = 0;
+        this._def = 0;
+        this._mat = 0;
+        this._mdf = 0;
+    }
+}
+
 /**
  * 画面の入力をもとに、計算を行う
  */
@@ -22,21 +150,16 @@ function calculation() {
     const lukTotal = Number(safeEval(safeReplace($('#lukTotal').val())));
 
     // 結果の初期化
-    let powResult = powTotal; // POW結果
-    let intResult = intTotal; // POW結果
-    let spdResult = spdTotal; // POW結果
-    let vitResult = vitTotal; // POW結果
-    let lukResult = lukTotal; // POW結果
-    let atkResult = atkTotal; // ATK結果
-    let defResult = defTotal; // DEF結果
-    let matResult = matTotal; // MAT結果
-    let mdfResult = mdfTotal; // MDF結果
+    let result = new PISVLADMaMd(powTotal, intTotal, spdTotal, vitTotal, lukTotal, atkTotal, defTotal, matTotal, mdfTotal);
 
     // リキッドの上昇値
     let atkLiquidBuff = 0; // リキッドのATK上昇値
     let defLiquidBuff = 0; // リキッドのDEF上昇値
     let matLiquidBuff = 0; // リキッドのMAT上昇値
     let mdfLiquidBuff = 0; // リキッドのMDF上昇値
+
+    // 魔獣缶・シールの上昇値
+    let canSealBuff = new PISVL();
 
     // エル羽の上昇値
     let atkElBuff = 0; // エル羽のATK上昇値
@@ -53,250 +176,280 @@ function calculation() {
         if (taskName == "powBita") {
             let powBuff = parseInt(powStatus * 0.2); // POW上昇値
             powBuff = Math.max(1, powBuff); // POW上昇値が 0 以下だったら、上昇値は 1 とする
-            powResult += powBuff;
-            atkResult += powBuff * 3;
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
         }
         if (taskName == "intBita") {
             let intBuff = parseInt(intStatus * 0.2); // INT上昇値
             intBuff = Math.max(1, intBuff); // INT上昇値が 0 以下だったら、上昇値は 1 とする
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            result.int += intBuff;
+            result.mat += intBuff * 2;
+            result.mdf += intBuff * 15;
         }
         if (taskName == "spdBita") {
             let spdBuff = parseInt(spdStatus * 0.2); // SPD上昇値
             spdBuff = Math.max(1, spdBuff); // SPD上昇値が 0 以下だったら、上昇値は 1 とする
-            spdResult += spdBuff;
+            result.spd += spdBuff;
         }
         if (taskName == "vitBita") {
             let vitBuff = parseInt(vitStatus * 0.2); // VIT上昇値
             vitBuff = Math.max(1, vitBuff); // VIT上昇値が 0 以下だったら、上昇値は 1 とする
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            result.vit += vitBuff;
+            result.def += vitBuff * 2;
         }
         if (taskName == "lukBita") {
             let lukBuff = parseInt(lukStatus * 0.2); // LUK上昇値
             lukBuff = Math.max(1, lukBuff); // LUK上昇値が 0 以下だったら、上昇値は 1 とする
-            lukResult += lukBuff;
+            result.luk += lukBuff;
         }
         if (taskName == "allBita") {
             let powBuff = parseInt(powStatus * 0.1); // POW上昇値
             powBuff = Math.max(1, powBuff); // POW上昇値が 0 以下だったら、上昇値は 1 とする
-            powResult += powBuff;
-            atkResult += powBuff * 3;
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
             let intBuff = parseInt(intStatus * 0.1); // INT上昇値
             intBuff = Math.max(1, intBuff); // INT上昇値が 0 以下だったら、上昇値は 1 とする
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            result.int += intBuff;
+            result.mat += intBuff * 2;
+            result.mdf += intBuff * 15;
             let spdBuff = parseInt(spdStatus * 0.1); // SPD上昇値
             spdBuff = Math.max(1, spdBuff); // SPD上昇値が 0 以下だったら、上昇値は 1 とする
-            spdResult += spdBuff;
+            result.spd += spdBuff;
             let vitBuff = parseInt(vitStatus * 0.1); // VIT上昇値
             vitBuff = Math.max(1, vitBuff); // VIT上昇値が 0 以下だったら、上昇値は 1 とする
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            result.vit += vitBuff;
+            result.def += vitBuff * 2;
             let lukBuff = parseInt(lukStatus * 0.1); // LUK上昇値
             lukBuff = Math.max(1, lukBuff); // LUK上昇値が 0 以下だったら、上昇値は 1 とする
-            lukResult += lukBuff;
+            result.luk += lukBuff;
         }
 
         // 魔獣缶処理
         if (taskName == "powCan") {
-            let powBuff = 10; // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
-            let intBuff = -10; // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.pow = 10; // POW上昇値
+            result.pow += canSealBuff.pow;
+            result.atk += canSealBuff.pow * 3;
+            canSealBuff.int = -10; // INT上昇値
+            result.int += canSealBuff.int;
+            result.mat += canSealBuff.int * 2;
+            result.mdf += canSealBuff.int * 15;
         }
         if (taskName == "intCan") {
-            let intBuff = 10; // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
-            let vitBuff = -10; // VIT上昇値
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.int = 10; // INT上昇値
+            result.int += canSealBuff.int;
+            result.mat += canSealBuff.int * 2;
+            result.mdf += canSealBuff.int * 15;
+            canSealBuff.vit = -10; // VIT上昇値
+            result.vit += canSealBuff.vit;
+            result.def += canSealBuff.vit * 2;
         }
 
         // シール処理
         if (taskName == "powSeal") {
-            let powBuff = 15; // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
-            let intBuff = -15; // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.pow = 15; // POW上昇値
+            result.pow += canSealBuff.pow;
+            result.atk += canSealBuff.pow * 3;
+            canSealBuff.int = -15; // INT上昇値
+            result.int += canSealBuff.int;
+            result.mat += canSealBuff.int * 2;
+            result.mdf += canSealBuff.int * 15;
         }
         if (taskName == "intSeal") {
-            let powBuff = -15; // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
-            let intBuff = 15; // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.pow = -15; // POW上昇値
+            result.pow += canSealBuff.pow;
+            result.atk += canSealBuff.pow * 3;
+            canSealBuff.int = 15; // INT上昇値
+            result.int += canSealBuff.int;
+            result.mat += canSealBuff.int * 2;
+            result.mdf += canSealBuff.int * 15;
         }
         if (taskName == "spdSeal") {
-            let spdBuff = 15; // SPD上昇値
-            spdResult += spdBuff;
-            let lukBuff = -15; // LUK上昇値
-            lukResult += lukBuff;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.spd = 15; // SPD上昇値
+            result.spd += canSealBuff.spd;
+            canSealBuff.luk = -15; // LUK上昇値
+            result.luk += canSealBuff.luk;
         }
         if (taskName == "vitSeal") {
-            let spdBuff = -15; // SPD上昇値
-            spdResult += spdBuff;
-            let vitBuff = 15; // VIT上昇値
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.spd = -15; // SPD上昇値
+            result.spd += canSealBuff.spd;
+            canSealBuff.vit = 15; // VIT上昇値
+            result.vit += canSealBuff.vit;
+            result.def += canSealBuff.vit * 2;
         }
         if (taskName == "lukSeal") {
-            let vitBuff = -15; // VIT上昇値
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
-            let lukBuff = 15; // LUK上昇値
-            lukResult += lukBuff;
+            resetCanSealBuff(canSealBuff, result);
+            canSealBuff.vit = -15; // VIT上昇値
+            result.vit += canSealBuff.vit;
+            result.def += canSealBuff.vit * 2;
+            canSealBuff.luk = 15; // LUK上昇値
+            result.luk += canSealBuff.luk;
         }
 
         // ブレイク処理
         if (taskName == "break") {
             let powBuff = Number(task.find("input[name=powCard]").val()); // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
             let intBuff = Number(task.find("input[name=intCard]").val()); // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            result.int += intBuff;
+            result.mat += intBuff * 2;
+            result.mdf += intBuff * 15;
             let spdBuff = Number(task.find("input[name=spdCard]").val()); // SPD上昇値
-            spdResult += spdBuff;
+            result.spd += spdBuff;
             let vitBuff = Number(task.find("input[name=vitCard]").val()); // VIT上昇値
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            result.vit += vitBuff;
+            result.def += vitBuff * 2;
             let lukBuff = Number(task.find("input[name=lukCard]").val()); // LUK上昇値
-            lukResult += lukBuff;
+            result.luk += lukBuff;
         }
 
         // 巻物処理
         if (taskName == "powMakimono") {
             let powBuff = Number(task.children().val()); // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
         }
         if (taskName == "intMakimono") {
             let intBuff = Number(task.children().val()); // INT上昇値
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
+            result.int += intBuff;
+            result.mat += intBuff * 2;
+            result.mdf += intBuff * 15;
         }
         if (taskName == "spdMakimono") {
             let spdBuff = Number(task.children().val()); // SPD上昇値
-            spdResult += spdBuff;
+            result.spd += spdBuff;
         }
         if (taskName == "vitMakimono") {
             let vitBuff = Number(task.children().val()); // VIT上昇値
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
+            result.vit += vitBuff;
+            result.def += vitBuff * 2;
         }
         if (taskName == "lukMakimono") {
             let lukBuff = Number(task.children().val()); // LUK上昇値
-            lukResult += lukBuff;
+            result.luk += lukBuff;
         }
         if (taskName == "atkMakimono") {
             let atkBuff = Number(task.children().val()); // ATK上昇値
-            atkResult += atkBuff;
+            result.atk += atkBuff;
         }
         if (taskName == "defMakimono") {
             let atkBuff = Number(task.children().val()); // DEF上昇値
-            defResult += atkBuff;
+            result.def += atkBuff;
         }
         if (taskName == "matMakimono") {
             let atkBuff = Number(task.children().val()); // MAT上昇値
-            matResult += atkBuff;
+            result.mat += atkBuff;
         }
         if (taskName == "mdfMakimono") {
             let atkBuff = Number(task.children().val()); // MDF上昇値
-            mdfResult += atkBuff;
+            result.mdf += atkBuff;
         }
 
         // リキッド処理
         if (taskName == "powLiquid") {
-            let atkMagni = (level + powResult - 100) / 100; // ATK上昇倍率
-            atkLiquidBuff = parseInt((atkResult - powResult - atkElBuff) * Math.max(0.1, atkMagni)); // ATK上昇量
-            atkResult += atkLiquidBuff;
+            let atkMagni = (level + result.pow - 100) / 100; // ATK上昇倍率
+            atkLiquidBuff = parseInt((result.atk - result.pow - atkElBuff) * Math.max(0.1, atkMagni)); // ATK上昇量
+            result.atk += atkLiquidBuff;
         }
         if (taskName == "defLiquid") {
-            let defMagni = (level + vitResult - 100) / 100; // DEF上昇倍率
-            defLiquidBuff = parseInt((defResult - defElBuff) * Math.max(0.1, defMagni)); // DEF上昇量
-            defResult += defLiquidBuff;
+            let defMagni = (level + result.vit - 100) / 100; // DEF上昇倍率
+            defLiquidBuff = parseInt((result.def - defElBuff) * Math.max(0.1, defMagni)); // DEF上昇量
+            result.def += defLiquidBuff;
         }
         if (taskName == "matLiquid") {
-            let matMagni = (level + intResult - 100) / 100; // MAT上昇倍率
-            matLiquidBuff = parseInt((matResult - matElBuff) * Math.max(0.1, matMagni)); // MAT上昇量
-            matResult += matLiquidBuff;
+            let matMagni = (level + result.int - 100) / 100; // MAT上昇倍率
+            matLiquidBuff = parseInt((result.mat - matElBuff) * Math.max(0.1, matMagni)); // MAT上昇量
+            result.mat += matLiquidBuff;
         }
         if (taskName == "mdfLiquid") {
-            let maxIntOrVit = Math.max(intResult, vitResult) // INT or VIT の大きい値を取る
+            let maxIntOrVit = Math.max(result.int, result.vit) // INT or VIT の大きい値を取る
             let mdfMagni = (level + maxIntOrVit - 100) / 100; // MDF上昇倍率
-            mdfLiquidBuff = parseInt((mdfResult - (intResult * 15) + (maxIntOrVit * 2) - mdfElBuff) * Math.max(0.1, mdfMagni)); // MDF上昇量
-            mdfResult += mdfLiquidBuff;
+            mdfLiquidBuff = parseInt((result.mdf - (result.int * 15) + (maxIntOrVit * 2) - mdfElBuff) * Math.max(0.1, mdfMagni)); // MDF上昇量
+            result.mdf += mdfLiquidBuff;
         }
 
         // スキル処理
         if (taskName == "bloodScraper") {
             let powBuff = 9; // POW上昇値
-            powResult += powBuff;
-            atkResult += powBuff * 3;
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
         }
         if (taskName == "elysion") {
-            let powBuff = parseInt(powResult * 0.2); // POW上昇値
+            let powBuff = parseInt(result.pow * 0.2); // POW上昇値
             powBuff = Math.max(1, powBuff); // POW上昇値が 0 以下だったら、上昇値は 1 とする
-            powResult += powBuff;
-            atkResult += powBuff * 3;
-            let intBuff = parseInt(intResult * 0.2); // INT上昇値
+            result.pow += powBuff;
+            result.atk += powBuff * 3;
+            let intBuff = parseInt(result.int * 0.2); // INT上昇値
             intBuff = Math.max(1, intBuff); // INT上昇値が 0 以下だったら、上昇値は 1 とする
-            intResult += intBuff;
-            matResult += intBuff * 2;
-            mdfResult += intBuff * 15;
-            let spdBuff = parseInt(spdResult * 0.2); // SPD上昇値
+            result.int += intBuff;
+            result.mat += intBuff * 2;
+            result.mdf += intBuff * 15;
+            let spdBuff = parseInt(result.spd * 0.2); // SPD上昇値
             spdBuff = Math.max(1, spdBuff); // SPD上昇値が 0 以下だったら、上昇値は 1 とする
-            spdResult += spdBuff;
-            let vitBuff = parseInt(vitResult * 0.2); // VIT上昇値
+            result.spd += spdBuff;
+            let vitBuff = parseInt(result.vit * 0.2); // VIT上昇値
             vitBuff = Math.max(1, vitBuff); // VIT上昇値が 0 以下だったら、上昇値は 1 とする
-            vitResult += vitBuff;
-            defResult += vitBuff * 2;
-            let lukBuff = parseInt(lukResult * 0.2); // LUK上昇値
+            result.vit += vitBuff;
+            result.def += vitBuff * 2;
+            let lukBuff = parseInt(result.luk * 0.2); // LUK上昇値
             lukBuff = Math.max(1, lukBuff); // LUK上昇値が 0 以下だったら、上昇値は 1 とする
-            lukResult += lukBuff;
+            result.luk += lukBuff;
 
-            atkElBuff = parseInt((atkTotal - (powTotal * 3) + (powResult * 2)) * 0.2); // エル羽のATK上昇量
-            atkResult += atkElBuff;
-            defElBuff = parseInt((defTotal - (vitTotal * 2) + (vitResult * 2)) * 0.2); // エル羽のDEF上昇量
-            defResult += defElBuff;
-            matElBuff = parseInt((matTotal - (intTotal * 2) + (intResult * 2)) * 0.2); // エル羽のMAT上昇量
-            matResult += matElBuff;
-            let maxIntOrVit = Math.max(intResult, vitResult); // INT or VIT の大きい値を取る
+            atkElBuff = parseInt((atkTotal - (powTotal * 3) + (result.pow * 2)) * 0.2); // エル羽のATK上昇量
+            result.atk += atkElBuff;
+            defElBuff = parseInt((defTotal - (vitTotal * 2) + (result.vit * 2)) * 0.2); // エル羽のDEF上昇量
+            result.def += defElBuff;
+            matElBuff = parseInt((matTotal - (intTotal * 2) + (result.int * 2)) * 0.2); // エル羽のMAT上昇量
+            result.mat += matElBuff;
+            let maxIntOrVit = Math.max(result.int, result.vit); // INT or VIT の大きい値を取る
             mdfElBuff = parseInt((mdfTotal - (intTotal * 15) + (maxIntOrVit * 2)) * 0.2); // エル羽のMDF上昇量
-            mdfResult += mdfElBuff;
+            result.mdf += mdfElBuff;
         }
         if (taskName == "apophis") {
-            let lukBuff = parseInt(lukResult * 0.3); // LUK上昇値
-            lukResult += lukBuff;
+            let lukBuff = parseInt(result.luk * 0.3); // LUK上昇値
+            result.luk += lukBuff;
         }
     });
 
     // 結果の表示
-    $('#powResult').text(powResult);
-    $('#intResult').text(intResult);
-    $('#spdResult').text(spdResult);
-    $('#vitResult').text(vitResult);
-    $('#lukResult').text(lukResult);
-    $('#atkResult').text(atkResult + "(上昇値：" + atkLiquidBuff + ")");
-    $('#defResult').text(defResult + "(上昇値：" + defLiquidBuff + ")");
-    $('#matResult').text(matResult + "(上昇値：" + matLiquidBuff + ")");
-    $('#mdfResult').text(mdfResult + "(上昇値：" + mdfLiquidBuff + ")");
+    $('#powResult').text(result.pow);
+    $('#intResult').text(result.int);
+    $('#spdResult').text(result.spd);
+    $('#vitResult').text(result.vit);
+    $('#lukResult').text(result.luk);
+    $('#atkResult').text(result.atk + "(上昇値：" + atkLiquidBuff + ")");
+    $('#defResult').text(result.def + "(上昇値：" + defLiquidBuff + ")");
+    $('#matResult').text(result.mat + "(上昇値：" + matLiquidBuff + ")");
+    $('#mdfResult').text(result.mdf + "(上昇値：" + mdfLiquidBuff + ")");
+}
+
+/**
+ * 魔獣缶・シールの上昇値をリセットする
+ */
+function resetCanSealBuff(canSealBuff, result) {
+    // POW上昇による効果のリセット
+    result.pow -= canSealBuff.pow;
+    result.atk -= canSealBuff.pow * 3;
+    // INT上昇による効果のリセット
+    result.int -= canSealBuff.int;
+    result.mat -= canSealBuff.int * 2;
+    result.mdf -= canSealBuff.int * 15;
+    // SPD上昇による効果のリセット
+    result.spd -= canSealBuff.spd;
+    // VIT上昇による効果のリセット
+    result.vit -= canSealBuff.vit;
+    result.def -= canSealBuff.vit * 2;
+    // LUK上昇による効果のリセット
+    result.luk -= canSealBuff.luk;
+
+    // 上昇値のリセット
+    canSealBuff.reset();
 }
 
 /**


### PR DESCRIPTION
魔獣缶・シールの上昇値を保持し、魔獣缶・シールの処理がある場合には上長値をリセットする。
魔獣缶・シールの上昇値を保持するために、上昇値用のクラスを作成。
また、結果を再計算するために、結果用のクラスを作成。